### PR TITLE
Fixes #39

### DIFF
--- a/components/shellbridge.py
+++ b/components/shellbridge.py
@@ -170,8 +170,7 @@ def blockSpotifyUpdate(active):
         try:
             # Check for existance before deleting update path and making it
             if os.path.exists(os.path.join(os.environ['LOCALAPPDATA'], "Spotify", "Update")):
-                shutil.rmtree(os.path.join(
-                    os.environ['LOCALAPPDATA'], "Spotify", "Update"))
+                return
             os.makedirs(os.path.join(
                 os.environ['LOCALAPPDATA'], "Spotify", "Update"))
 


### PR DESCRIPTION
Seems to fix the issue preventing the Manager from restarting after enabling the 'Block Spotify updates' option.